### PR TITLE
ratecounter count() return total

### DIFF
--- a/rate_counter.go
+++ b/rate_counter.go
@@ -25,7 +25,9 @@ type RateCounter interface {
 type StandardRateCounter struct {
 	clock clock.Clock
 
-	counter        int64 // lastCount "lags behind" by a sample period by design, this one really counts all events.
+	// lastCount "lags behind" by a sample period by design, this one really counts all events so far.
+	// Note that lastCount is at par with lastRate, so that in MonViz rate(meter.lastCount) = meter.lastRate
+	counter        int64
 	samplePeriodMs int64
 	windowSizeMs   int64
 

--- a/rate_counter_test.go
+++ b/rate_counter_test.go
@@ -90,8 +90,9 @@ func TestSnapshot(t *testing.T) {
 	}
 }
 
-func TestRateAndCountInSnapshotShouldBeConsistent(t *testing.T) {
-	// If new data isn't present in Snapshot.Rate1() it shouldn't be present in Snapshot.Count()
+func TestRateAndLastCountInSnapshotShouldBeConsistent(t *testing.T) {
+	// If new data isn't present in Snapshot.Rate1() it shouldn't be present in counter.lastCount but it should
+	// in Snapshot.Count()
 
 	m := clock.NewMock()
 	rc := NewStandardRateCounter(60, 1000, m)
@@ -99,11 +100,16 @@ func TestRateAndCountInSnapshotShouldBeConsistent(t *testing.T) {
 	rc.Mark(1)
 	s := rc.Snapshot()
 
+	// since we don't advance the time, the sampling period is still current, and there is nothing finalized for rate or .lastCount
+	// but this doesn't matter for Count()
 	if v := s.Rate1(); v != 0.0 {
 		t.Errorf("s.Rate1(): 0.0 != %v\n", v)
 	}
+	if v := rc.(*StandardRateCounter).lastCount; v != 0.0 {
+		t.Errorf("s.lastCount: 0.0 != %v\n", v)
+	}
 	if v := s.Count(); v != 1.0 {
-		t.Errorf("s.Count(): 0.0 != %v\n", v)
+		t.Errorf("s.Count(): 1.0 != %v\n", v)
 	}
 
 	m.Add(1 * time.Second)

--- a/rate_counter_test.go
+++ b/rate_counter_test.go
@@ -102,7 +102,7 @@ func TestRateAndCountInSnapshotShouldBeConsistent(t *testing.T) {
 	if v := s.Rate1(); v != 0.0 {
 		t.Errorf("s.Rate1(): 0.0 != %v\n", v)
 	}
-	if v := s.Count(); v != 0.0 {
+	if v := s.Count(); v != 1.0 {
 		t.Errorf("s.Count(): 0.0 != %v\n", v)
 	}
 


### PR DESCRIPTION
the rateCounter was returning the count up to the last period, but we really want the total count
(this was done so rate(meter.count) = meter.1m in monviz)